### PR TITLE
update all installed yum packages first thing.

### DIFF
--- a/tasks/yum.yml
+++ b/tasks/yum.yml
@@ -1,15 +1,14 @@
 ---
-- name: Clean yum.
-  command: yum -y clean all
+- name: Yum update
+  yum: name=* state=latest update_cache=yes
 - name: Packages for yum.
-  yum: name={{ item }} state=latest update_cache=yes
+  yum: name={{ item }} state=latest
   with_items:
   - yum
   - yum-cron
   - deltarpm
   - epel-release
   - yum-priorities
-  retries: 1
 - name: yum-cron set for security updates
   lineinfile: "dest=/etc/yum/yum-cron.conf state=present regexp='^update_cmd = default$' line='update_cmd = security'"
 - name: yum-cron apply updates


### PR DESCRIPTION
Updates all installed yum packages first thing.
## Motivation and Context

We want to be able to manage older centos/rhel7 boxes out there. Without this change, rhel bug 1293513 currently prevents that.
https://github.com/OULibraries/ansible-role-centos7/issues/10
## How Has This Been Tested?

I applied this to a couple of older and newer boxes without issue.
