### PR TITLE
Add bash-completion package.

### DIFF
--- a/tasks/yum.yml
+++ b/tasks/yum.yml
@@ -37,6 +37,7 @@
   yum: name={{ item }} state=present
   with_items:
   - ack
+  - bash-completion
   - curl
   - emacs-nox
   - git


### PR DESCRIPTION
This adds bash-completion to the list of packages installed by yum. 
## Motivation and Context

I really like auto complete. 
## How Has This Been Tested?

Role installed and auto-complete verified. 
