### PR TITLE
Optionally create swapfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,13 @@ A target system running CentOS7x.
 Role Variables
 --------------
 
+* centos7_swap optionally creates and enables a swapfile of the specified path and size. The example below would give you a 4GiB swap at /swapfile0
+```
+centos7_swap:
+  file_path: /swapfile0
+  file_size: 4194304
+```
+
 vpshere tagged tasks expect server_name, server_ip, and broker_ip.
 * servername is the value for the hostname. Defaults to current FQDN.
 * server_ip sets the NIC address (Gateway, Netmask, and DNS should already be configured in your base image). Defaults to current address. We set this because we set the IP after firing up a base box on a known addres.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,3 +3,4 @@ server_tag_name: "{{ hostvars['localhost']['server_tag_name'] }}"
 server_ip:  "{{ ansible_default_ipv4.address }}"
 server_name: "{{ inventory_hostname }}"
 server_timezone: 'America/Chicago'
+centos7_swap:

--- a/tasks/setup.yml
+++ b/tasks/setup.yml
@@ -12,7 +12,8 @@
 - name: Create swap file
   command: >
     dd if=/dev/zero of={{ centos7_swap.file_path }} bs=1024 count={{ centos7_swap.file_size }}
-  creates: "{{ centos7_swap.file_path }}"
+  args:
+    creates: "{{ centos7_swap.file_path }}"
   when: ((centos7_swap is defined) and (centos7_swap is not none))
 
 - name: Change swap file permissions
@@ -36,12 +37,13 @@
 
 - name: Write swap entry in fstab
   mount:
-    name: none
+    name: swap
     src: "{{ centos7_swap.file_path }}"
     fstype: swap
     opts: defaults
     dump: 0
     passno: 0
+    state: present
   when: ((centos7_swap is defined) and (centos7_swap is not none))
 
 - name: Ensure /usr/local belongs to root:wheel 0775

--- a/tasks/setup.yml
+++ b/tasks/setup.yml
@@ -9,6 +9,41 @@
   notify:
   - Set timezone
 
+- name: Create swap file
+  command: >
+    dd if=/dev/zero of={{ centos7_swap.file_path }} bs=1024 count={{ centos7_swap.file_size }}
+  creates: "{{ centos7_swap.file_path }}"
+  when: ((centos7_swap is defined) and (centos7_swap is not none))
+
+- name: Change swap file permissions
+  file:
+    path: "{{ centos7_swap.file_path }}"
+    owner: root
+    group: root
+    mode: 0600
+  when: ((centos7_swap is defined) and (centos7_swap is not none))
+
+- name: Check swap file
+  command: >
+    grep '{{ centos7_swap.file_path }}' /proc/swaps
+  register: swapfile_test
+  when: ((centos7_swap is defined) and (centos7_swap is not none))
+
+- name: Make swap file
+  command: >
+    sudo mkswap {{ centos7_swap.file_path }}
+  when: ((centos7_swap is defined) and (centos7_swap is not none) and (swapfile_test.rc != 0))
+
+- name: Write swap entry in fstab
+  mount:
+    name: none
+    src: "{{ centos7_swap.file_path }}"
+    fstype: swap
+    opts: defaults
+    dump: 0
+    passno: 0
+  when: ((centos7_swap is defined) and (centos7_swap is not none))
+
 - name: Ensure /usr/local belongs to root:wheel 0775
   file:
     path: /usr/local


### PR DESCRIPTION
Optionally create swapfile of the specified path and size.  Don't do anything new by default.

Motivation and Context
----------------------
We've enabled swapfiles on a few boxes now, and we're not tracking that anywhere.
https://github.com/OULibraries/ansible-role-centos7/issues/26

How Has This Been Tested?
-------------------------
Tested new swap creation
Tested skipping of hosts with no swap specified
Tested "no change" on hosts that already had the specified swap file


Notes:
-------------------------
Doesn't check free space before running dd.
Doesn't check if swap is of the specified size
Only turns swap on, doesn't turn swap off
Doesn't do anything with swap partitions