### PR TITLE
Update yum.yml

### DIFF
--- a/tasks/yum.yml
+++ b/tasks/yum.yml
@@ -30,9 +30,6 @@
     - selinux-policy
     - selinux-policy-targeted
 
-- name: yum-cron set for security updates
-  lineinfile: "dest=/etc/yum/yum-cron.conf state=present regexp='^update_cmd = default$' line='update_cmd = security'"
-
 - name: yum-cron apply updates
   lineinfile: "dest=/etc/yum/yum-cron.conf state=present regexp='^apply_updates = no$' line='apply_updates = yes'"
 


### PR DESCRIPTION
Removal of security updates only update command for yum-cron. 
On CentOS you can only use yum-cron for automatic full upgrades as in:
update_cmd = default
otherwise you only get security upgrades from any external repositories you happen to use (like e.g. EPEL).
<link> https://serverfault.com/questions/795086/confirming-that-yum-cron-is-configured-properly-on-a-centos-7-server </link>

<!--- Replace this with the title of your PR, or specify the title above and delete this line-->

<!--- Replace this with a detailed description of your changes -->

Motivation and Context
----------------------
<!--- Why is this change required? What problem does it solve? -->
<!--- If it relates to an open issue or another pull request, please link to that here. -->

How Has This Been Tested?
-------------------------

