### PR TITLE
Tag SELinux tasks and cleanup platform/hypervisor/distro detection logic

### DIFF
--- a/tasks/ec2_setup.yml
+++ b/tasks/ec2_setup.yml
@@ -24,5 +24,17 @@
 - name: Set hostname to instance name
   shell: hostnamectl set-hostname "{{ server_tag_name.stdout }}"
 
-- name: Also set /etc/hosts for legacy
-  lineinfile: dest=/etc/hosts line="{{ ansible_eth0.ipv4.address }} {{ server_tag_name.stdout }}"
+- name: Set /etc/hosts from eth0 for legacy if possible
+  lineinfile:
+    dest: /etc/hosts
+    line: "{{ ansible_eth0.ipv4.address }} {{ server_tag_name.stdout }}"
+  when: >
+    (ansible_eth0 is defined) and (ansible_eth0 is not none)
+
+# This has come up on newer AWS CentOS7 images.
+- name: Otherwise /etc/hosts from ens5 for legacy if possible
+  lineinfile:
+    dest: /etc/hosts
+    line: "{{ ansible_ens5.ipv4.address }} {{ server_tag_name.stdout }}"
+  when: >
+    (ansible_eth0 is not defined or ansible_eth0 is none) and (ansible_ens5 is defined and ansible_ens5 is not none)

--- a/tasks/ec2_setup.yml
+++ b/tasks/ec2_setup.yml
@@ -29,7 +29,7 @@
     dest: /etc/hosts
     line: "{{ ansible_eth0.ipv4.address }} {{ server_tag_name.stdout }}"
   when: >
-    (ansible_eth0 is defined) and (ansible_eth0 is not none)
+    ansible_eth0 is defined and ansible_eth0 is not none
 
 # This has come up on newer AWS CentOS7 images.
 - name: Otherwise /etc/hosts from ens5 for legacy if possible

--- a/tasks/fact_check.yml
+++ b/tasks/fact_check.yml
@@ -12,5 +12,5 @@
 # Setting these facts makes the conditionals in our main task file more legible and DRY.
 - set_fact:
     is_centos7: "{{ (ansible_distribution == 'CentOS' or ansible_distribution == 'RedHat') and ansible_distribution_major_version == '7' }}"
-    is_ec2_guest: "{{ (ec2_uri_check.status == 200) or ('amazon' in ansible_product_version and ansible_virtualization_role == 'guest') }}"
+    is_ec2_guest: "{{ ec2_uri_check.status == 200 or ('amazon' in ansible_product_version and ansible_virtualization_role == 'guest') }}"
     is_vmware_guest: "{{ ansible_virtualization_type == 'VMware' and ansible_virtualization_role == 'guest' }}"

--- a/tasks/fact_check.yml
+++ b/tasks/fact_check.yml
@@ -1,0 +1,16 @@
+---
+
+# This lets us check for EC2 even if we can't gather the facts as expected via Ansible.
+# This can happen with new generations of EC2 instances and when IAM permissions are extremely restrictive.
+- name: Check if inside AWS EC2.
+  uri:
+    url: http://169.254.169.254/latest/meta-data
+    timeout: 2
+  register: ec2_uri_check
+  failed_when: False
+
+# Setting these facts makes the conditionals in our main task file more legible and DRY.
+- set_fact:
+    is_centos7: "{{ (ansible_distribution == 'CentOS' or ansible_distribution == 'RedHat') and ansible_distribution_major_version == '7' }}"
+    is_ec2_guest: "{{ (ec2_uri_check.status == 200) or ('amazon' in ansible_product_version and ansible_virtualization_role == 'guest') }}"
+    is_vmware_guest: "{{ ansible_virtualization_type == 'VMware' and ansible_virtualization_role == 'guest' }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,43 +1,46 @@
 ---
+
+- include: fact_check.yml
+
 - include: yum.yml
-  when: (((ansible_distribution == "CentOS") or (ansible_distribution == "RedHat")) and (ansible_distribution_major_version == "7"))
+  when: is_centos7
   become: true
   tags:
   - centos7_yum
 
 - include: setup.yml
-  when: (((ansible_distribution == "CentOS") or (ansible_distribution == "RedHat")) and (ansible_distribution_major_version == "7"))
+  when: is_centos7
   become: true
   tags:
   - centos7_setup
 
 - include: assets.yml
-  when: (((ansible_distribution == "CentOS") or (ansible_distribution == "RedHat")) and (ansible_distribution_major_version == "7"))
+  when: is_centos7
   become: true
   tags:
   - centos7_assets
 
 - include: ec2_assets.yml
-  when: (((ansible_distribution == "CentOS") or (ansible_distribution == "RedHat")) and (ansible_distribution_major_version == "7") and ("amazon" in ansible_product_version) and (ansible_virtualization_type == "xen") and (ansible_virtualization_role == "guest"))
+  when: is_centos7 and is_ec2_guest
   become: true
   tags:
   - centos7_ec2
   - centos7_assets
 
 - include: ec2_setup.yml
-  when: (((ansible_distribution == "CentOS") or (ansible_distribution == "RedHat")) and (ansible_distribution_major_version == "7") and ("amazon" in ansible_product_version) and (ansible_virtualization_type == "xen") and (ansible_virtualization_role == "guest"))
+  when: is_centos7 and is_ec2_guest
   become: true
   tags:
   - centos7_ec2
 
 - include: vmware.yml
-  when: (((ansible_distribution == "CentOS") or (ansible_distribution == "RedHat")) and (ansible_distribution_major_version == "7") and (ansible_virtualization_type == "VMware") and (ansible_virtualization_role == "guest"))
+  when: is_centos7 and is_vmware_guest
   become: true
   tags:
   - centos7_vmware_guest
 
 - include: metal_or_vmware_guest.yml
-  when: (((ansible_distribution == "CentOS") or (ansible_distribution == "RedHat")) and (ansible_distribution_major_version == "7") and ((ansible_virtualization_role == "host") or ((ansible_virtualization_type == "VMware") and (ansible_virtualization_role == "guest"))))
+  when: is_centos7 and (ansible_virtualization_role == "host" or is_vmware_guest)
   become: true
   tags:
   - centos7_metal

--- a/tasks/yum.yml
+++ b/tasks/yum.yml
@@ -29,6 +29,7 @@
     - polkit
     - selinux-policy
     - selinux-policy-targeted
+  tags: selinux
 
 - name: yum-cron apply updates
   lineinfile: "dest=/etc/yum/yum-cron.conf state=present regexp='^apply_updates = no$' line='apply_updates = yes'"


### PR DESCRIPTION
Tag SELinux tasks and cleanup platform/hypervisor/distro detection logic

Adds a tag to SELinux tasks so that they may be run selectively. Changes up the way platform/hypervisor/distro detection logic to be more DRY and to work more consistently with newer CentOS7 images on new t3 aws instances.

Motivation and Context
----------------------
Closes #30 
Closes #31 

How Has This Been Tested?
-------------------------
I've used this fork to deploy the latest CentOS7 images to AWS t3 instances and to a local docker-based CICD environment. Have not tested on metal or VMware, and if you peek at the changes, you'll see I slightly changed up the detection logic to make it easier to read and DRY.


