### PR TITLE
Remove old backup script, and support kvm virtualization at ec2

### DIFF
--- a/tasks/ec2_assets.yml
+++ b/tasks/ec2_assets.yml
@@ -32,22 +32,6 @@
     group: wheel
     recurse: yes
 
-- name: Remove existing ebs-snapshot.cron
-  file:
-    path: /etc/cron.daily/ebs-snapshot.cron
-    state: absent
-
-- name: download ebs-snapshot.sh to /opt/oulib/aws/bin
-  get_url:
-    url: https://github.com/OULibraries/aws-ec2-ebs-automatic-snapshot-bash/raw/v20170315.0/ebs-snapshot.sh
-    dest: /opt/oulib/aws/bin/ebs-snapshot.sh
-    checksum: md5:cf922fb1c9519f7da7e4b09640aacda4
-    mode: 0755
-    owner: root
-    group: root
-  when: ((centos_7_ebs_snapshot_retention_days is defined) and (centos_7_ebs_snapshot_retention_days is not none))
-  tags: assets
-
 - name: Copy helper scripts to /opt/oulib/aws/bin
   copy:
     src: "{{ item }}"
@@ -60,12 +44,3 @@
     - ec2_get_arn.sh
     - ec2_get_region.sh
   tags: assets
-
-- name: Add ebs-snapshot.cron to /etc/cron.daily
-  template:
-    src: ebs-snapshot.cron.j2
-    dest: /etc/cron.daily/ebs-snapshot.cron
-    mode: 0755
-    owner: root
-    group: root
-  when: ((centos_7_ebs_snapshot_retention_days is defined) and (centos_7_ebs_snapshot_retention_days is not none))

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -18,14 +18,20 @@
   - centos7_assets
 
 - include: ec2_assets.yml
-  when: (((ansible_distribution == "CentOS") or (ansible_distribution == "RedHat")) and (ansible_distribution_major_version == "7") and ("amazon" in ansible_product_version) and (ansible_virtualization_type == "xen") and (ansible_virtualization_role == "guest"))
+  when: (((ansible_distribution == "CentOS") or (ansible_distribution == "RedHat")) 
+          and (ansible_distribution_major_version == "7") 
+          and (ansible_virtualization_type == "xen" or ansible_virtualization_type == "kvm" ) 
+          and (ansible_virtualization_role == "guest"))
   become: true
   tags:
   - centos7_ec2
   - centos7_assets
 
 - include: ec2_setup.yml
-  when: (((ansible_distribution == "CentOS") or (ansible_distribution == "RedHat")) and (ansible_distribution_major_version == "7") and ("amazon" in ansible_product_version) and (ansible_virtualization_type == "xen") and (ansible_virtualization_role == "guest"))
+  when: (((ansible_distribution == "CentOS") or (ansible_distribution == "RedHat")) 
+          and (ansible_distribution_major_version == "7") 
+          and (ansible_virtualization_type == "xen" or ansible_virtualization_type == "kvm" ) 
+          and (ansible_virtualization_role == "guest"))
   become: true
   tags:
   - centos7_ec2


### PR DESCRIPTION
We're triggering snapshots based on tags, so we don't need the snapshot script. 

Also, the t3 instance types run on kvm now. 