### PR TITLE
Use special "always" tag on fact_check.yml.

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,6 +1,8 @@
 ---
 
 - include: fact_check.yml
+  tags:
+  - always
 
 - include: yum.yml
   when: is_centos7


### PR DESCRIPTION
Many of the tasks in this role need variables set by the fact_check.yml
playbook, so we tag it with the special "always" tag to make sure that it runs. 