### PR TITLE
added setroubleshoot packages to yum.yml

### DIFF
--- a/tasks/yum.yml
+++ b/tasks/yum.yml
@@ -25,6 +25,8 @@
       - polkit
       - selinux-policy
       - selinux-policy-targeted
+      - setroubleshoot-plugins.noarch
+      - setroubleshoot.x86_64
     state: present
   tags: selinux
 


### PR DESCRIPTION
I added the yum packages to install setroubleshoot tools on our default Centos 7 builds. This was to ensure that the tools exist on our vms rather than installing them when troubleshooting is necessary. This was the case with running audit2why on ShareOK vms and needing to follow the recommendations to correct SELinux context for certain directories.
