### PR TITLE
Remove awscli component

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -132,7 +132,8 @@ galaxy_info:
   #- packaging
   # - system
   #- web
-dependencies: []
+dependencies: 
+  - OULibraries.aws
   # List your role dependencies here, one per line.
   # Be sure to remove the '[]' above if you add dependencies
   # to this list.

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -132,9 +132,8 @@ galaxy_info:
   #- packaging
   # - system
   #- web
-dependencies: 
-  - OULibraries.aws
+dependencies:
+  - OULibraries.awscli
   # List your role dependencies here, one per line.
   # Be sure to remove the '[]' above if you add dependencies
   # to this list.
-

--- a/tasks/ec2_assets.yml
+++ b/tasks/ec2_assets.yml
@@ -1,10 +1,5 @@
 ---
 
-- name: Enxure that awscli is installed
-  yum:
-    name: awscli
-    state: present
-
 - name: Ensure /opt/oulib/aws/bin exists
   file:
     path: /opt/oulib/aws/bin

--- a/tasks/ec2_setup.yml
+++ b/tasks/ec2_setup.yml
@@ -20,7 +20,7 @@
 - name: Get instance Name tag
   shell: >
     set -o pipefail
-    && aws ec2 describe-tags --filters 
+    && /usr/local/bin/aws ec2 describe-tags --filters 
     "Name=resource-id,Values={{ instance_id.content }}"
     "Name=key,Values=Name" --region "{{ region.stdout }}"
     | jq --raw-output '.Tags|.[0]|.["Value"]'


### PR DESCRIPTION
<!--- Replace this with the title of your PR, or specify the title above and delete this line-->
Remove components for installing awscli
<!--- Replace this with a detailed description of your changes -->
Add dependency for this role on the awscli role and remove component for installing yum-managed awcli from this role.
Motivation and Context
----------------------
<!--- Why is this change required? What problem does it solve? -->
This change breaks out the management and installation of the awscli tool in order to bring it up-to-date and prevent us from depending on the yum-managed version of the awscli tool. 
<!--- If it relates to an open issue or another pull request, please link to that here. -->

How Has This Been Tested?
-------------------------
This role in its proposed iteration has been tested against the `ojs-upgrade` box.
